### PR TITLE
refactor: base and core package to be more generic

### DIFF
--- a/ext/file/sink.go
+++ b/ext/file/sink.go
@@ -62,12 +62,8 @@ func (fs *FileSink) process() error {
 	logCheckPoint := 1000
 	recordCounter := 0
 	for v := range fs.Read() {
-		raw, ok := v.([]byte)
-		if !ok {
-			return fmt.Errorf("invalid data type")
-		}
 		var record model.Record
-		if err := json.Unmarshal(raw, &record); err != nil {
+		if err := json.Unmarshal(v, &record); err != nil {
 			return errors.WithStack(err)
 		}
 		destinationURI, err := compiler.Compile(fs.destinationURITemplate, model.ToMap(record))
@@ -96,7 +92,7 @@ func (fs *FileSink) process() error {
 		}
 
 		recordWithoutMetadata := fs.RecordWithoutMetadata(record)
-		raw, err = json.Marshal(recordWithoutMetadata)
+		raw, err := json.Marshal(recordWithoutMetadata)
 		if err != nil {
 			fs.Logger().Error(fmt.Sprintf("failed to marshal record"))
 			return errors.WithStack(err)

--- a/ext/http/sink.go
+++ b/ext/http/sink.go
@@ -102,15 +102,9 @@ func (s *HTTPSink) process() error {
 	// log checkpoint
 	logCheckPoint := 500
 	recordCounter := 0
-	for msg := range s.Read() {
-		b, ok := msg.([]byte)
-		if !ok {
-			s.Logger().Error(fmt.Sprintf("invalid message type: %T", msg))
-			return fmt.Errorf("invalid message type: %T", msg)
-		}
-
+	for v := range s.Read() {
 		var record model.Record
-		if err := json.Unmarshal(b, &record); err != nil {
+		if err := json.Unmarshal(v, &record); err != nil {
 			s.Logger().Error(fmt.Sprintf("invalid data format"))
 			return errors.WithStack(err)
 		}
@@ -130,7 +124,7 @@ func (s *HTTPSink) process() error {
 		}
 
 		hash := hashMetadata(m)
-		_, ok = s.httpHandlers[hash]
+		_, ok := s.httpHandlers[hash]
 		if !ok {
 			s.httpHandlers[hash] = httpHandler{
 				httpMetadata: m,

--- a/ext/io/sink.go
+++ b/ext/io/sink.go
@@ -40,9 +40,9 @@ func NewSink(l *slog.Logger) *IOSink {
 func (s *IOSink) process() error {
 	// read from channel
 	for v := range s.Read() {
-		s.Logger().Debug(fmt.Sprintf("read: %s", string(v.([]byte))))
-		fmt.Fprintf(s.w, "%s\n", string(v.([]byte)))
-		s.Logger().Debug(fmt.Sprintf("done: %s", string(v.([]byte))))
+		s.Logger().Debug(fmt.Sprintf("read: %s", string(v)))
+		fmt.Fprintf(s.w, "%s\n", string(v))
+		s.Logger().Debug(fmt.Sprintf("done: %s", string(v)))
 	}
 	return nil
 }

--- a/ext/kafka/sink.go
+++ b/ext/kafka/sink.go
@@ -61,14 +61,8 @@ func (k *KafkaSink) process() error {
 	// read from channel
 	k.Logger().Info(fmt.Sprintf("start reading from source"))
 	for v := range k.Read() {
-		raw, ok := v.([]byte)
-		if !ok {
-			k.Logger().Error(fmt.Sprintf("invalid data format"))
-			return fmt.Errorf("invalid data format")
-		}
-
 		var record model.Record
-		if err := json.Unmarshal(raw, &record); err != nil {
+		if err := json.Unmarshal(v, &record); err != nil {
 			k.Logger().Error(fmt.Sprintf("invalid data format"))
 			return errors.WithStack(err)
 		}

--- a/ext/maxcompute/sink.go
+++ b/ext/maxcompute/sink.go
@@ -150,22 +150,15 @@ func (mc *MaxcomputeSink) process() error {
 	mc.Logger().Info(fmt.Sprintf("start writing records to table: %s", mc.tableSchema.TableName))
 	mc.Logger().Debug(fmt.Sprintf("record column: %+v", mc.tableSchema.Columns))
 	countRecord := 0
-	for msg := range mc.Read() {
-		b, ok := msg.([]byte)
-		if !ok {
-			err := fmt.Errorf("message type assertion error: %T", msg)
-			mc.Logger().Error(fmt.Sprintf("message type assertion error: %s", err.Error()))
-			return errors.WithStack(err)
-		}
-
+	for v := range mc.Read() {
 		var record model.Record
-		if err := json.Unmarshal(b, &record); err != nil {
+		if err := json.Unmarshal(v, &record); err != nil {
 			mc.Logger().Error(fmt.Sprintf("message unmarshal error: %s", err.Error()))
 			return errors.WithStack(err)
 		}
 		record = mc.RecordWithoutMetadata(record)
 
-		mc.Logger().Debug(fmt.Sprintf("message: %s", string(b)))
+		mc.Logger().Debug(fmt.Sprintf("message: %s", string(v)))
 		mcRecord, err := createRecord(mc.Logger(), record, mc.tableSchema)
 		if err != nil {
 			mc.Logger().Error(fmt.Sprintf("record creation error: %s", err.Error()))

--- a/ext/oss/sink.go
+++ b/ext/oss/sink.go
@@ -114,16 +114,10 @@ func (o *OSSSink) process() error {
 		logCheckPoint = o.batchSize
 	}
 
-	for msg := range o.Read() {
-		b, ok := msg.([]byte)
-		if !ok {
-			o.Logger().Error(fmt.Sprintf("message type assertion error: %T", msg))
-			return errors.New(fmt.Sprintf("message type assertion error: %T", msg))
-		}
-		o.Logger().Debug(fmt.Sprintf("received message: %s", string(b)))
-
+	for v := range o.Read() {
+		o.Logger().Debug(fmt.Sprintf("received message: %s", string(v)))
 		var record model.Record
-		if err := json.Unmarshal(b, &record); err != nil {
+		if err := json.Unmarshal(v, &record); err != nil {
 			o.Logger().Error(fmt.Sprintf("invalid data format"))
 			return errors.WithStack(err)
 		}

--- a/ext/postgresql/sink.go
+++ b/ext/postgresql/sink.go
@@ -73,17 +73,11 @@ func NewSink(ctx context.Context, l *slog.Logger,
 }
 
 func (p *PGSink) process() error {
-	for msg := range p.Read() {
-		b, ok := msg.([]byte)
-		if !ok {
-			p.Logger().Error(fmt.Sprintf("invalid message type"))
-			return errors.WithStack(errors.New(fmt.Sprintf("invalid message type: %T", msg)))
-		}
-		p.Logger().Debug(fmt.Sprintf("received message: %s", string(b)))
-
+	for v := range p.Read() {
+		p.Logger().Debug(fmt.Sprintf("received message: %s", string(v)))
 		var record model.Record
-		if err := json.Unmarshal(b, &record); err != nil {
-			p.Logger().Error(fmt.Sprintf("failed to unmarshal message: %s", string(b)))
+		if err := json.Unmarshal(v, &record); err != nil {
+			p.Logger().Error(fmt.Sprintf("failed to unmarshal message: %s", string(v)))
 			return errors.WithStack(err)
 		}
 

--- a/ext/redis/sink.go
+++ b/ext/redis/sink.go
@@ -107,16 +107,11 @@ func NewSink(ctx context.Context, l *slog.Logger,
 }
 
 func (s *RedisSink) process() error {
-	for msg := range s.Read() {
-		b, ok := msg.([]byte)
-		if !ok {
-			s.Logger().Error(fmt.Sprintf("message type assertion error: %T", msg))
-			return fmt.Errorf("message type assertion error: %T", msg)
-		}
-		s.Logger().Debug(fmt.Sprintf("received message: %s", string(b)))
+	for v := range s.Read() {
+		s.Logger().Debug(fmt.Sprintf("received message: %s", string(v)))
 
 		var record model.Record
-		if err := json.Unmarshal(b, &record); err != nil {
+		if err := json.Unmarshal(v, &record); err != nil {
 			s.Logger().Error(fmt.Sprintf("invalid data format"))
 			return errors.WithStack(err)
 		}

--- a/ext/sftp/sink.go
+++ b/ext/sftp/sink.go
@@ -87,16 +87,11 @@ func NewSink(ctx context.Context, l *slog.Logger,
 }
 
 func (s *SFTPSink) process() error {
-	for msg := range s.Read() {
-		b, ok := msg.([]byte)
-		if !ok {
-			s.Logger().Error(fmt.Sprintf("message type assertion error: %T", msg))
-			return fmt.Errorf("message type assertion error: %T", msg)
-		}
-		s.Logger().Debug(fmt.Sprintf("receive message: %s", string(b)))
+	for v := range s.Read() {
+		s.Logger().Debug(fmt.Sprintf("receive message: %s", string(v)))
 
 		var record model.Record
-		if err := json.Unmarshal(b, &record); err != nil {
+		if err := json.Unmarshal(v, &record); err != nil {
 			s.Logger().Error(fmt.Sprintf("invalid data format"))
 			return errors.WithStack(err)
 		}
@@ -125,7 +120,7 @@ func (s *SFTPSink) process() error {
 			s.fileHandlers[destinationURI] = fh
 		}
 		if err := s.Retry(func() error {
-			_, err := fh.Write(append(b, '\n'))
+			_, err := fh.Write(append(v, '\n'))
 			return err
 		}); err != nil {
 			s.Logger().Error(fmt.Sprintf("failed to write data"))

--- a/ext/smtp/sink.go
+++ b/ext/smtp/sink.go
@@ -148,11 +148,11 @@ func NewSink(ctx context.Context, l *slog.Logger,
 }
 
 func (s *SMTPSink) process() error {
-	for msg := range s.Read() {
+	for v := range s.Read() {
 		s.Logger().Debug(fmt.Sprintf("received message"))
 
 		var record model.Record
-		if err := json.Unmarshal(msg.([]byte), &record); err != nil {
+		if err := json.Unmarshal(v, &record); err != nil {
 			s.Logger().Error(fmt.Sprintf("unmarshal error: %s", err.Error()))
 			return errors.WithStack(err)
 		}

--- a/internal/component/common/source.go
+++ b/internal/component/common/source.go
@@ -33,7 +33,7 @@ func NewCommonSource(l *slog.Logger, name string, opts ...Option) *CommonSource 
 
 // Send sends the given data to the source.
 // This is a wrapper around the CoreSource's Send method.
-func (c *CommonSource) Send(v any) {
+func (c *CommonSource) Send(v []byte) {
 	sendCount, err := c.m.Int64Counter("send_count", metric.WithDescription("The total number of data sent"))
 	if err != nil {
 		c.Logger().Error(fmt.Sprintf("send count error: %s", err.Error()))
@@ -43,7 +43,7 @@ func (c *CommonSource) Send(v any) {
 		c.Logger().Error(fmt.Sprintf("send bytes error: %s", err.Error()))
 	}
 	sendCount.Add(context.Background(), 1)
-	sendBytes.Add(context.Background(), int64(len(v.([]byte))))
+	sendBytes.Add(context.Background(), int64(len(v)))
 
 	c.CoreSource.Send(v)
 }

--- a/pkg/component/base.go
+++ b/pkg/component/base.go
@@ -10,7 +10,6 @@ import (
 // It is used as a base for other components.
 type Base struct {
 	l          *slog.Logger
-	c          chan any
 	err        error
 	cleanFuncs []func() error
 }
@@ -19,7 +18,6 @@ type Base struct {
 func NewBase(l *slog.Logger, cleanFuncs ...func() error) *Base {
 	b := &Base{
 		l:          l,
-		c:          make(chan any),
 		err:        nil,
 		cleanFuncs: make([]func() error, 0),
 	}

--- a/pkg/component/sink.go
+++ b/pkg/component/sink.go
@@ -1,6 +1,7 @@
 package component
 
 import (
+	"iter"
 	"log/slog"
 
 	"github.com/goto/optimus-any2any/pkg/flow"
@@ -24,8 +25,8 @@ func NewCoreSink(l *slog.Logger, name string) *CoreSink {
 	// this is to prevent the sink from blocking
 	c.Core.postHookProcess = func() error {
 		c.Core.Logger().Debug("skip message")
-		for _, ok := <-c.Read(); ok; _, ok = <-c.Read() {
-			// drain the channel if it still contains messages
+		for range c.Read() {
+			// drain the channel
 		}
 		c.Core.Logger().Debug("process done")
 		c.done <- 0
@@ -35,13 +36,8 @@ func NewCoreSink(l *slog.Logger, name string) *CoreSink {
 }
 
 // Read returns the channel to read from
-func (c *CoreSink) Read() <-chan any {
-	return c.Core.c
-}
-
-// In returns the channel to write to
-func (c *CoreSink) In() chan<- any {
-	return c.Core.c
+func (c *CoreSink) Read() iter.Seq[[]byte] {
+	return c.Out()
 }
 
 // Wait waits for the sink to finish processing

--- a/pkg/component/source.go
+++ b/pkg/component/source.go
@@ -29,12 +29,7 @@ func NewCoreSource(l *slog.Logger, name string) *CoreSource {
 	return c
 }
 
-// Out returns the channel to read from
-func (c *CoreSource) Out() <-chan any {
-	return c.Core.c
-}
-
 // Send sends a value to the channel
-func (c *CoreSource) Send(v any) {
-	c.Core.c <- v
+func (c *CoreSource) Send(v []byte) {
+	c.In(v)
 }

--- a/pkg/connector/fanout.go
+++ b/pkg/connector/fanout.go
@@ -14,15 +14,15 @@ func FanOut(l *slog.Logger) flow.ConnectMultiSink {
 			defer func() {
 				l.Debug("connector(fanout): close")
 				for _, inlet := range inlets {
-					close(inlet.In())
+					inlet.CloseInlet()
 				}
 			}()
 			for v := range outlet.Out() {
-				l.Debug(fmt.Sprintf("connector(fanout): send: %s", string(v.([]byte))))
+				l.Debug(fmt.Sprintf("connector(fanout): send: %s", string(v)))
 				for _, inlet := range inlets {
-					inlet.In() <- v
+					inlet.In(v)
 				}
-				l.Debug(fmt.Sprintf("connector(fanout): done: %s", string(v.([]byte))))
+				l.Debug(fmt.Sprintf("connector(fanout): done: %s", string(v)))
 			}
 		}()
 	}

--- a/pkg/connector/passthrough.go
+++ b/pkg/connector/passthrough.go
@@ -13,12 +13,12 @@ func PassThrough(l *slog.Logger) flow.Connect {
 		go func() {
 			defer func() {
 				l.Debug("connector(passthrough): close")
-				close(inlet.In())
+				inlet.CloseInlet()
 			}()
 			for v := range outlet.Out() {
-				l.Debug(fmt.Sprintf("connector(passthrough): send: %s", string(v.([]byte))))
-				inlet.In() <- v
-				l.Debug(fmt.Sprintf("connector(passthrough): done: %s", string(v.([]byte))))
+				l.Debug(fmt.Sprintf("connector(passthrough): send: %s", string(v)))
+				inlet.In(v)
+				l.Debug(fmt.Sprintf("connector(passthrough): done: %s", string(v)))
 			}
 		}()
 	}

--- a/pkg/flow/flow.go
+++ b/pkg/flow/flow.go
@@ -1,13 +1,16 @@
 package flow
 
+import "iter"
+
 // Inlet is an interface for a component that can receive data.
 type Inlet interface {
-	In() chan<- any
+	In([]byte)
+	CloseInlet() error
 }
 
 // Outlet is an interface for a component that can send data.
 type Outlet interface {
-	Out() <-chan any
+	Out() iter.Seq[[]byte]
 }
 
 // Source is an interface for source components.


### PR DESCRIPTION
- [x] channel to use `[]byte` data type to avoid unnecessary casting
- [x] return `iter.Seq` instead of chan, for iterating the record
- [x] inlet to use message param and explicit close method instead of exposing the channel