### PR TITLE
fix: properly close inlets by using buffered chan

### DIFF
--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -40,7 +40,7 @@ func (c *Connector) Connect() flow.ConnectMultiSink {
 }
 
 func (c *Connector) connect(outlet flow.Outlet, inlets ...flow.Inlet) {
-	errChan := make(chan error)
+	errChan := make(chan error, 1)
 	go func() {
 		defer func() {
 			c.l.Info("close inlets")


### PR DESCRIPTION
**Summary**

This fixes issue where errors in source process does not properly terminate the any2any process.