### PR TITLE
fix: increase scanner buffer + add sf log

### DIFF
--- a/ext/file/source.go
+++ b/ext/file/source.go
@@ -91,6 +91,9 @@ func (fs *FileSource) Process() error {
 				// send to channel
 				fs.Send(line)
 			}
+			if err := sc.Err(); err != nil {
+				return errors.WithStack(err)
+			}
 			return nil
 		})
 	}

--- a/ext/http/sink.go
+++ b/ext/http/sink.go
@@ -255,6 +255,9 @@ func compileMetadata(m httpMetadataTemplate, record *model.Record) (httpMetadata
 			}
 			metadata.headers[parts[0]] = append(metadata.headers[parts[0]], strings.Split(parts[1], ",")...)
 		}
+		if err := sc.Err(); err != nil {
+			return metadata, errors.WithStack(err)
+		}
 	}
 
 	return metadata, nil

--- a/ext/oss/source.go
+++ b/ext/oss/source.go
@@ -128,6 +128,10 @@ func (o *OSSSource) process() error {
 				o.Logger().Info(fmt.Sprintf("sent %d records", recordCounter))
 			}
 		}
+		if err := sc.Err(); err != nil {
+			o.Logger().Error(fmt.Sprintf("failed to read object: %s", oss.ToString(objectProp.Key)))
+			return errors.WithStack(err)
+		}
 	}
 	o.Logger().Info(fmt.Sprintf("successfully sent %d records", recordCounter))
 	return nil

--- a/pkg/component/connector_jq.go
+++ b/pkg/component/connector_jq.go
@@ -98,6 +98,10 @@ func processBatch(ctx context.Context, l *slog.Logger, query string, batchData [
 		copy(line, raw)
 		inlet.In(line)
 	}
+	if err := sc.Err(); err != nil {
+		l.Error(fmt.Sprintf("failed to read transformed JSON: %v", err))
+		return errors.WithStack(err)
+	}
 
 	return nil
 }


### PR DESCRIPTION
**issue:**
scanner error suppressed, the actual error:
```sh
2025-05-20T17:28:56+07:00 ERROR source(sf): failed to read from sink: bufio.Scanner: token too long
```

**fixes:**
- [x] don't ignore scanner error
- [x] increase buffer scanner to 1MB