### PR TITLE
chore(smtp-sink): increase client timeout to 2 minutes

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ It applies when sink and source are in the same environment. For example, transf
 | | SMTP__COMPRESSION_TYPE | If set, the resulting files will be archived into the selected type. Supported types: `auto`, `gz`, `gzip`, `tar.gz`, and `zip` |
 | | SMTP__COMPRESSION_PASSWORD | Set password for the resulting archive file. Only supported for `zip` compression_type |
 | | SMTP__SKIP_HEADER | Skip header for CSV file format. (default: false) |
+| | SMTP__CONNECTION_TIMEOUT_SECONDS | SMTP connection timeout in seconds. (default: 120s - 2 minutes) |
 | POSTGRES | PG__CONNECTION_DSN | Postgres connection DSN. |
 | | PG__DESTINATION_TABLE_ID | Destination table ID in Postgres. |
 | | PG__PRE_SQL_SCRIPT | SQL script to run before the data transfer. |

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ It applies when sink and source are in the same environment. For example, transf
 | | SMTP__COMPRESSION_TYPE | If set, the resulting files will be archived into the selected type. Supported types: `auto`, `gz`, `gzip`, `tar.gz`, and `zip` |
 | | SMTP__COMPRESSION_PASSWORD | Set password for the resulting archive file. Only supported for `zip` compression_type |
 | | SMTP__SKIP_HEADER | Skip header for CSV file format. (default: false) |
-| | SMTP__CONNECTION_TIMEOUT_SECONDS | SMTP connection timeout in seconds. (default: 120s - 2 minutes) |
+| | SMTP__CONNECTION_TIMEOUT_SECONDS | SMTP connection timeout in seconds. Default: 120s (2 minutes) |
 | POSTGRES | PG__CONNECTION_DSN | Postgres connection DSN. |
 | | PG__DESTINATION_TABLE_ID | Destination table ID in Postgres. |
 | | PG__PRE_SQL_SCRIPT | SQL script to run before the data transfer. |

--- a/ext/smtp/client.go
+++ b/ext/smtp/client.go
@@ -25,7 +25,7 @@ type SMTPClient struct {
 }
 
 // NewSMTPClient creates a new SMTPClient
-func NewSMTPClient(ctx context.Context, connectionDSN string) (*SMTPClient, error) {
+func NewSMTPClient(ctx context.Context, connectionDSN string, connectionTimeout int) (*SMTPClient, error) {
 	dsn, err := url.Parse(connectionDSN)
 	if err != nil {
 		err = fmt.Errorf("error parsing connection dsn")
@@ -49,8 +49,13 @@ func NewSMTPClient(ctx context.Context, connectionDSN string) (*SMTPClient, erro
 		port = p
 	}
 
+	connectionTimeoutDuration := defaultConnTimeout
+	if connectionTimeout > 0 {
+		connectionTimeoutDuration = time.Duration(connectionTimeout) * time.Second
+	}
+
 	client, err := mail.NewClient(host,
-		mail.WithTimeout(defaultConnTimeout),
+		mail.WithTimeout(connectionTimeoutDuration),
 		mail.WithTLSPortPolicy(mail.TLSMandatory),
 		mail.WithSMTPAuth(mail.SMTPAuthPlain),
 		mail.WithUsername(username),

--- a/ext/smtp/client.go
+++ b/ext/smtp/client.go
@@ -7,9 +7,15 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/wneessen/go-mail"
+)
+
+const (
+	// default connection timeout set to 2 minutes
+	defaultConnTimeout = 120 * time.Second
 )
 
 // SMTPClient is a wrapper around gomail.SendCloser
@@ -44,6 +50,7 @@ func NewSMTPClient(ctx context.Context, connectionDSN string) (*SMTPClient, erro
 	}
 
 	client, err := mail.NewClient(host,
+		mail.WithTimeout(defaultConnTimeout),
 		mail.WithTLSPortPolicy(mail.TLSMandatory),
 		mail.WithSMTPAuth(mail.SMTPAuthPlain),
 		mail.WithUsername(username),

--- a/ext/smtp/sink.go
+++ b/ext/smtp/sink.go
@@ -88,11 +88,11 @@ func NewSink(commonSink common.Sink,
 	connectionDSN string, from, to, subject, bodyFilePath, bodyNoRecordFilePath, attachment string,
 	storageConfig StorageConfig,
 	skipHeader bool,
-	compressionType string, compressionPassword string,
+	compressionType string, compressionPassword string, connectionTimeout int,
 	opts ...common.Option) (*SMTPSink, error) {
 
 	// create SMTP client
-	client, err := NewSMTPClient(commonSink.Context(), connectionDSN)
+	client, err := NewSMTPClient(commonSink.Context(), connectionDSN, connectionTimeout)
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}

--- a/internal/component/component.go
+++ b/internal/component/component.go
@@ -208,6 +208,7 @@ func GetSink(ctx context.Context, cancelFn context.CancelCauseFunc, l *slog.Logg
 			sinkCfg.BodyFilePath, sinkCfg.BodyNoRecordFilePath, sinkCfg.AttachmentFilename, storageCfg,
 			sinkCfg.SkipHeader,
 			sinkCfg.CompressionType, sinkCfg.CompressionPassword,
+			sinkCfg.ConnectionTimeoutSeconds,
 			opts...)
 	case PSQL:
 		sinkCfg, err := config.SinkPG(envs...)

--- a/internal/config/sink_smtp.go
+++ b/internal/config/sink_smtp.go
@@ -2,20 +2,21 @@ package config
 
 // SinkSMTPConfig is a configuration for the sink smtp component.
 type SinkSMTPConfig struct {
-	ConnectionDSN         string `env:"SMTP__CONNECTION_DSN"`
-	From                  string `env:"SMTP__FROM"`
-	To                    string `env:"SMTP__TO"`
-	Subject               string `env:"SMTP__SUBJECT"`
-	BodyFilePath          string `env:"SMTP__BODY_FILE_PATH"`
-	BodyNoRecordFilePath  string `env:"SMTP__BODY_NO_RECORD_FILE_PATH"`
-	AttachmentFilename    string `env:"SMTP__ATTACHMENT_FILENAME"`
-	StorageMode           string `env:"SMTP__STORAGE_MODE" envDefault:"attachment"`
-	StorageDestinationDir string `env:"SMTP__STORAGE_DESTINATION_DIR"`
-	StorageLinkExpiration int    `env:"SMTP__STORAGE_LINK_EXPIRATION" envDefault:"604800"`
-	StorageCredentials    string `env:"SMTP__STORAGE_CREDENTIALS"`
-	CompressionPassword   string `env:"SMTP__COMPRESSION_PASSWORD"`
-	CompressionType       string `env:"SMTP__COMPRESSION_TYPE"`
-	SkipHeader            bool   `env:"SMTP__SKIP_HEADER" default:"false"`
+	ConnectionDSN            string `env:"SMTP__CONNECTION_DSN"`
+	From                     string `env:"SMTP__FROM"`
+	To                       string `env:"SMTP__TO"`
+	Subject                  string `env:"SMTP__SUBJECT"`
+	BodyFilePath             string `env:"SMTP__BODY_FILE_PATH"`
+	BodyNoRecordFilePath     string `env:"SMTP__BODY_NO_RECORD_FILE_PATH"`
+	AttachmentFilename       string `env:"SMTP__ATTACHMENT_FILENAME"`
+	StorageMode              string `env:"SMTP__STORAGE_MODE" envDefault:"attachment"`
+	StorageDestinationDir    string `env:"SMTP__STORAGE_DESTINATION_DIR"`
+	StorageLinkExpiration    int    `env:"SMTP__STORAGE_LINK_EXPIRATION" envDefault:"604800"`
+	StorageCredentials       string `env:"SMTP__STORAGE_CREDENTIALS"`
+	CompressionPassword      string `env:"SMTP__COMPRESSION_PASSWORD"`
+	CompressionType          string `env:"SMTP__COMPRESSION_TYPE"`
+	SkipHeader               bool   `env:"SMTP__SKIP_HEADER" default:"false"`
+	ConnectionTimeoutSeconds int    `env:"SMTP__CONNECTION_TIMEOUT_SECONDS" envDefault:"120"`
 }
 
 // SinkSMTP parses the environment variables and returns the sink smtp configuration.


### PR DESCRIPTION
### Summary
- Increasing default timeout for SMTP client to be 2 minutes to handle large attachment being sent.
- expose connection timeout as configurable to users