### PR TITLE
chore(source): set default SOURCE_CONCURRENCY to 1

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -12,7 +12,7 @@ type Config struct {
 	RetryMax                  int    `env:"RETRY_MAX" envDefault:"3"`
 	RetryBackoffMs            int64  `env:"RETRY_BACKOFF_MS" envDefault:"1000"`
 	EnablePprof               bool   `env:"ENABLE_PPROF" envDefault:"false"`
-	SourceConcurrency         int    `env:"SOURCE_CONCURRENCY" envDefault:"4"`
+	SourceConcurrency         int    `env:"SOURCE_CONCURRENCY" envDefault:"1"`
 	SinkConcurrency           int    `env:"SINK_CONCURRENCY" envDefault:"4"`
 	ConnectorConcurrency      int    `env:"CONNECTOR_CONCURRENCY" envDefault:"4"`
 	ConnectorProcessor        string `env:"CONNECTOR_PROCESSOR" envDefault:"JQ"` // JQ or PY


### PR DESCRIPTION
### Summary
Since introduction of concurrency in sources leaves a possibility for records' ordering to be mixed up, default setting for the number of source concurrency will be set to 1 to avoid breaking changes.