### PR TITLE
fix(http-sink): reinitialize http request on retry

### DIFF
--- a/ext/http/sink.go
+++ b/ext/http/sink.go
@@ -10,9 +10,9 @@ import (
 	"strings"
 	"text/template"
 
+	"github.com/goto/optimus-any2any/internal/component/common"
 	xauth "github.com/goto/optimus-any2any/internal/ext/auth"
 	"github.com/goto/optimus-any2any/internal/ext/compiler"
-	"github.com/goto/optimus-any2any/internal/component/common"
 	"github.com/goto/optimus-any2any/internal/ext/model"
 	xnet "github.com/goto/optimus-any2any/internal/ext/net"
 	"github.com/goto/optimus-any2any/pkg/flow"
@@ -215,17 +215,17 @@ func (s *HTTPSink) flush(m httpMetadata, records []*model.Record) error {
 		return errors.WithStack(err)
 	}
 
-	req := http.Request{
-		Method:        m.method,
-		URL:           u,
-		Header:        m.headers,
-		ContentLength: int64(len([]byte(body))),
-		Body:          io.NopCloser(strings.NewReader(body)),
-	}
-
 	err = s.ConcurrentQueue(func() error {
 		return s.Retry(func() error {
 			return s.DryRunable(func() error {
+				req := http.Request{
+					Method:        m.method,
+					URL:           u,
+					Header:        m.headers,
+					ContentLength: int64(len([]byte(body))),
+					Body:          io.NopCloser(strings.NewReader(body)),
+				}
+
 				resp, err := s.client.Do(req.WithContext(s.Context()))
 				if err != nil {
 					return errors.WithStack(err)


### PR DESCRIPTION
### Summary
This fixes HTTP sink on retry mechanism to reinitialize request inside retry enclosure, instead of reusing the same `req` object.

In current logic, when the first request fails, if retry is enabled it will retry the HTTP call using the same retry. This caused issue on the next retry because the request body is already consumed and therefore empty. Reproducible below by using default client timeout of 10s & leave request hanging for a while.
<img width="1118" height="275" alt="image" src="https://github.com/user-attachments/assets/f43b7ea0-84a2-42c7-a44f-431a18d9f9cc" />
